### PR TITLE
Improve GitHub repository UI and AI prompt feedback

### DIFF
--- a/code_editor_page.dart
+++ b/code_editor_page.dart
@@ -111,7 +111,7 @@ class _CodeEditorPageState extends State<CodeEditorPage> with TickerProviderStat
         }
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No changes suggested by AI')),
+          const SnackBar(content: Text('AI did not generate changes. Try refining your prompt.')),
         );
       }
     } catch (e) {
@@ -277,6 +277,8 @@ class _CodeEditorPageState extends State<CodeEditorPage> with TickerProviderStat
   }
 
   Widget _buildFileInfoBar() {
+    final repo = GitHubService().selectedRepository.value;
+    final branch = GitHubService().currentBranch.value;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       decoration: BoxDecoration(
@@ -294,6 +296,16 @@ class _CodeEditorPageState extends State<CodeEditorPage> with TickerProviderStat
               fontSize: 12,
             ),
           ),
+          const SizedBox(width: 16),
+          if (repo != null)
+            Text(
+              '${repo.name}/$branch',
+              style: TextStyle(
+                color: Colors.grey.shade600,
+                fontSize: 12,
+                fontFamily: 'monospace',
+              ),
+            ),
           const Spacer(),
           if (_hasUnsavedChanges)
             Container(

--- a/github_page.dart
+++ b/github_page.dart
@@ -294,9 +294,13 @@ class _GitHubPageState extends State<GitHubPage> with TickerProviderStateMixin {
   }
 
   Widget _buildRepositoryCard(GitHubRepository repo) {
+    final isSelected = _gitHubService.selectedRepository.value?.id == repo.id;
     return Card(
+      color: isSelected ? Colors.grey.shade50 : Colors.white,
       margin: const EdgeInsets.only(bottom: 12),
       child: ListTile(
+        selected: isSelected,
+        selectedTileColor: Colors.grey.shade100,
         leading: Icon(
           repo.isPrivate ? Icons.lock : Icons.folder_outlined,
           color: repo.isPrivate ? Colors.orange : Colors.blue,
@@ -337,10 +341,10 @@ class _GitHubPageState extends State<GitHubPage> with TickerProviderStateMixin {
         trailing: ValueListenableBuilder<GitHubRepository?>(
           valueListenable: _gitHubService.selectedRepository,
           builder: (context, selectedRepo, child) {
-            final isSelected = selectedRepo?.id == repo.id;
+            final selected = selectedRepo?.id == repo.id;
             return Icon(
-              isSelected ? Icons.check_circle : Icons.radio_button_unchecked,
-              color: isSelected ? Colors.green : Colors.grey.shade400,
+              selected ? Icons.check_circle : Icons.radio_button_unchecked,
+              color: selected ? Colors.green : Colors.grey.shade400,
             );
           },
         ),
@@ -501,12 +505,19 @@ class _FileBrowserWidgetState extends State<FileBrowserWidget> {
             const SizedBox(width: 8),
           ],
           Expanded(
-            child: Text(
-              _currentPath.isEmpty ? '/' : '/$_currentPath',
-              style: const TextStyle(
-                fontFamily: 'monospace',
-                fontSize: 14,
-              ),
+            child: ValueListenableBuilder<GitHubRepository?>(
+              valueListenable: _gitHubService.selectedRepository,
+              builder: (context, repo, child) {
+                final path = _currentPath.isEmpty ? '/' : '/$_currentPath';
+                final prefix = repo != null ? '${repo.name} ' : '';
+                return Text(
+                  '$prefix$path',
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 14,
+                  ),
+                );
+              },
             ),
           ),
           ValueListenableBuilder<String>(
@@ -538,6 +549,7 @@ class _FileBrowserWidgetState extends State<FileBrowserWidget> {
       itemBuilder: (context, index) {
         final file = _currentFiles[index];
         return ListTile(
+          tileColor: Colors.white,
           leading: Icon(
             file.type == 'dir' ? Icons.folder : Icons.description,
             color: file.type == 'dir' ? Colors.blue : Colors.grey.shade600,
@@ -546,12 +558,8 @@ class _FileBrowserWidgetState extends State<FileBrowserWidget> {
           subtitle: file.type == 'file'
               ? Text('${(file.size / 1024).toStringAsFixed(1)} KB')
               : null,
-          trailing: file.type == 'file'
-              ? IconButton(
-                  icon: const Icon(Icons.edit),
-                  onPressed: () => _openFileEditor(file),
-                )
-              : const Icon(Icons.chevron_right),
+          trailing:
+              file.type == 'dir' ? const Icon(Icons.chevron_right) : null,
           onTap: () {
             if (file.type == 'dir') {
               _navigateToPath(file.path, file.name);


### PR DESCRIPTION
## Summary
- refine repository list UI with better white/grey usage
- hide edit button in file browser and open editor on tap
- show repository name and branch in path bar
- add repo/branch info in editor file bar
- improve message when AI produces no changes

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: unable to locate package)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879c374cd3083329f056b967b788fc5